### PR TITLE
fix: notify if profile data is empty on exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,12 @@ class ClinicDoctor extends events.EventEmitter {
       if (os.platform() !== 'win32') proc.kill('SIGINT')
     })
 
+    process.once('beforeExit', function () {
+      if (!fs.existsSync(paths['/processstat']) || fs.statSync(paths['/processstat']).size === 0) {
+        console.log('Profile data collected seems to be empty, report may not be generated')
+      }
+    })
+
     proc.once('exit', (code, signal) => {
       // Windows exit code STATUS_CONTROL_C_EXIT 0xC000013A returns 3221225786
       // if not caught. See https://msdn.microsoft.com/en-us/library/cc704588.aspx

--- a/test/cmd-collect-node-path-env.test.js
+++ b/test/cmd-collect-node-path-env.test.js
@@ -23,6 +23,7 @@ test('cmd - collect - NODE_PATH works', function (t) {
   child.stdout.pipe(endpoint(function (err, output) {
     if (err) return t.ifError(err)
 
-    t.strictEqual(output.toString().trim(), `${path.join(__dirname, '../injects')}${path.delimiter}${__dirname}`)
+    t.strictEqual(output.toString().trim(), `${path.join(__dirname, '../injects')}${path.delimiter}${__dirname}
+Profile data collected seems to be empty, report may not be generated`)
   }))
 })


### PR DESCRIPTION
Added a `beforeExit` hook that checks if `processstat` file has content and notify if not. 