### PR TITLE
doc: add issue repository location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Programmable interface to [Clinic.js][clinic-url] Doctor. Learn more about Clini
 
 ![Screenshot](screenshot.png)
 
+## Issues
+
+To open an issue, please use the [main repository](https://github.com/clinicjs/node-clinic) with the `doctor` label.
+
 ## Installation
 
 ```console


### PR DESCRIPTION
To improve the maintainability of this project. I've removed the "issues" tab and transferred all the open issues to node-clinic with `doctor` label.